### PR TITLE
Configure Postgres devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+    "name": "devapp",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "devapp",
+    "workspaceFolder": "/workspace/devapp",
+    "remoteUser": "vscode",
+    "forwardPorts": [8080],
+    "postCreateCommand": "mvn -q install -DskipTests"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  devapp:
+    image: mcr.microsoft.com/devcontainers/universal:2
+    volumes:
+      - ..:/workspace:cached
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: devdb
+      DB_USERNAME: devuser
+      DB_PASSWORD: devpass
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: devdb
+      POSTGRES_USER: devuser
+      POSTGRES_PASSWORD: devpass
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Simple set of microservices with the following requirements:
 - The backend is exposed through REST APIs with Swagger
 - The applications are Dockerized and are managed in a cluster through Kubernetes
 - The microservices do basic CRUD operation on a Postgres database
+- A PostgreSQL database is provided automatically when developing in the
+  provided devcontainer. The same configuration is reused in the Kubernetes
+  manifests through a deployment and service named `postgres`.
 - Microservices communicate through Kafka
 - Logging is done using ELK stack with ElasticSearch and Logstash and a Kibana dashboard
 - Monitoring is done through Prometheus and Grafana
@@ -15,3 +18,7 @@ Optionally, add:
 - Authentication is managed by Okta
 - Set up Kubernetes and Docker (with private registry)
 - Tools (Gitlab, JIRA, Confluence, Nexus/Artifactory)
+
+## Local Development
+
+Open the project with VS Code and reopen in the container when prompted. A PostgreSQL database is started automatically and the Java dependencies are preinstalled.

--- a/assembly/order-app-deployment.yaml
+++ b/assembly/order-app-deployment.yaml
@@ -17,3 +17,23 @@ spec:
         image: your-docker-hub-username/order-app
         ports:
         - containerPort: 8080
+        env:
+        - name: DB_HOST
+          value: postgres
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-config
+              key: POSTGRES_DB
+        - name: DB_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-config
+              key: POSTGRES_USER
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_PASSWORD

--- a/assembly/user-app-deployment.yaml
+++ b/assembly/user-app-deployment.yaml
@@ -17,3 +17,23 @@ spec:
         image: your-docker-hub-username/user-app
         ports:
         - containerPort: 8080
+        env:
+        - name: DB_HOST
+          value: postgres
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-config
+              key: POSTGRES_DB
+        - name: DB_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-config
+              key: POSTGRES_USER
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_PASSWORD

--- a/devapp-common/src/main/resources/application.properties
+++ b/devapp-common/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=order-service
 
 # application.properties
-spring.datasource.url=jdbc:postgresql://localhost:5432/yourdatabase
-spring.datasource.username=yourusername
-spring.datasource.password=yourpassword
+spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:devdb}
+spring.datasource.username=${DB_USERNAME:devuser}
+spring.datasource.password=${DB_PASSWORD:devpass}
 spring.jpa.hibernate.ddl-auto=update
 
 spring.kafka.bootstrap-servers=localhost:9092


### PR DESCRIPTION
## Summary
- make datasource configurable via environment variables
- add VS Code devcontainer with Postgres for local development
- wire Postgres connection in Kubernetes deployments
- document devcontainer usage

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68404701be1483219c08d2b977dbc9cc